### PR TITLE
Remove chronicler id placeholder and guard backup jobs

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,3 +2,4 @@
 TOKEN = 'your-bot-token'
 GROUP_CHAT_ID = 'your_tg_chat_token'
 BOT_HANDLER_ID = 'your_own_chatid'
+CHRONICLER_ID = 'your_chronicler_chatid'


### PR DESCRIPTION
## Summary
- replace the committed chronicler chat id with a placeholder value in the sample configuration
- add helper logic so chronicler backups only run when a chat id is configured

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d45b642cc4832db0b3625ff87b7ef3