### PR TITLE
Fix BOT_HANDLER_ID type coercion and zero-division in expense fun facts

### DIFF
--- a/maBot.py
+++ b/maBot.py
@@ -55,7 +55,7 @@ _spec.loader.exec_module(_config)
 # Bot token & UUID
 TOKEN = getattr(_config, "TOKEN")
 GROUP_CHAT_ID = getattr(_config, "GROUP_CHAT_ID")
-BOT_HANDLER_ID = getattr(_config, "BOT_HANDLER_ID")
+BOT_HANDLER_ID = int(getattr(_config, "BOT_HANDLER_ID"))
 CHRONICLER_ID = getattr(_config, "CHRONICLER_ID")
 NI_ID = getattr(_config, "NI_ID")
 GI_ID = getattr(_config, "GI_ID")
@@ -1825,7 +1825,7 @@ def _build_expense_fun_facts(expenses):
             )
 
         top_payer = max(payer_total, key=payer_total.get)
-        share_pct = payer_total[top_payer] / total_spend * 100
+        share_pct = payer_total[top_payer] / total_spend * 100 if total_spend else 0
         if share_pct >= 40:
             lines.append(
                 f"  • {top_payer} covered {share_pct:.0f}% of total spending"

--- a/maBot.py
+++ b/maBot.py
@@ -55,7 +55,10 @@ _spec.loader.exec_module(_config)
 # Bot token & UUID
 TOKEN = getattr(_config, "TOKEN")
 GROUP_CHAT_ID = getattr(_config, "GROUP_CHAT_ID")
-BOT_HANDLER_ID = int(getattr(_config, "BOT_HANDLER_ID"))
+try:
+    BOT_HANDLER_ID = int(getattr(_config, "BOT_HANDLER_ID"))
+except (TypeError, ValueError):
+    BOT_HANDLER_ID = None  # admin features disabled when unconfigured
 CHRONICLER_ID = getattr(_config, "CHRONICLER_ID")
 NI_ID = getattr(_config, "NI_ID")
 GI_ID = getattr(_config, "GI_ID")


### PR DESCRIPTION
## Summary

Two P1 bug fixes flagged in review:

- **BOT_HANDLER_ID type mismatch** — `update.effective_user.id` is always an `int`, but `BOT_HANDLER_ID` was loaded raw from config where it's commonly a quoted string. The `==` comparison silently failed, so the Admin Panel button never appeared and all admin actions were rejected as unauthorized. Fixed by casting to `int` at load time.

- **ZeroDivisionError in expense fun facts** — if 28-day expense entries net to zero (e.g. correction entries), `total_spend` is 0 and the top-payer share percentage calculation raised `ZeroDivisionError`, aborting the scheduled weekly report before it sent anything or persisted penalty updates. Fixed with a ternary guard.

## Test plan
- [ ] Admin Panel button visible in Settings when logged in as BOT_HANDLER_ID (even if config has a quoted/string ID)
- [ ] Trigger Weekly Report dry-run works without "Unauthorized" rejection
- [ ] Weekly report sends normally when all expense amounts sum to zero

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3)_