### PR TITLE
Reapply: aggregate weekly sessions per member for big moves

### DIFF
--- a/maBot.py
+++ b/maBot.py
@@ -1912,17 +1912,19 @@ def _build_weekly_report(data):
         names = ", ".join(comeback_kids)
         sections.append(f"Comeback of the week: {names} turned it around after lagging last week!")
 
-    # --- Big chore leaps this week (>1h = >4 pts in one session) ---
+    # --- Big moves this week: members with >1h total across all sessions ---
     week_entries = _chore_entries_this_week(data.get("chore_log") or [])
-    leaps = [e for e in week_entries if e.get("points", 0) > 4]
-    if leaps:
+    member_week_pts = {}
+    for e in week_entries:
+        member = e.get("member", "?")
+        member_week_pts[member] = member_week_pts.get(member, 0) + e.get("points", 0)
+    big_movers = {m: pts for m, pts in member_week_pts.items() if pts > 4}
+    if big_movers:
         leap_lines = []
-        for e in sorted(leaps, key=lambda x: -x.get("points", 0)):
-            mins = e["points"] * 15
-            desc = e.get("description", "")
-            desc_part = f' ("{desc}")' if desc else ""
-            leap_lines.append(f"  • {e['member']}: {mins} min{desc_part}")
-        sections.append("Big moves this week (>1h sessions):\n" + "\n".join(leap_lines))
+        for member, pts in sorted(big_movers.items(), key=lambda x: -x[1]):
+            mins = pts * 15
+            leap_lines.append(f"  • {member}: {mins} min total")
+        sections.append("Big moves this week:\n" + "\n".join(leap_lines))
 
     # --- Expense fun facts ---
     fun_facts = _build_expense_fun_facts(data.get("expenses") or [])


### PR DESCRIPTION
The nav-fix commit `2fe9b64` was based on an older file snapshot and silently overwrote the aggregation fix from issue #12.

## What changed
- "Big moves this week" now sums **all** chore_log entries per member across the past 7 days
- Anyone totalling >4 pts (>1h) gets a shoutout — so Janidputzä's two sessions (4+2=6 pts) now correctly appear alongside Thomath Sucker
- Removed the `(>1h sessions)` per-entry rule annotation from the header

## Test plan
- [ ] Dry-run report shows both Thomath Sucker (105 min) and Janidputzä (90 min) in Big moves
- [ ] Header reads "Big moves this week:" with no parenthetical

Closes #12

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3)_