### PR TITLE
Reformat weekly report: new title, descriptions, WG-Höck countdown

### DIFF
--- a/maBot.py
+++ b/maBot.py
@@ -1915,15 +1915,21 @@ def _build_weekly_report(data):
     # --- Big moves this week: members with >1h total across all sessions ---
     week_entries = _chore_entries_this_week(data.get("chore_log") or [])
     member_week_pts = {}
+    member_week_entries = {}
     for e in week_entries:
         member = e.get("member", "?")
         member_week_pts[member] = member_week_pts.get(member, 0) + e.get("points", 0)
+        member_week_entries.setdefault(member, []).append(e)
     big_movers = {m: pts for m, pts in member_week_pts.items() if pts > 4}
     if big_movers:
         leap_lines = []
         for member, pts in sorted(big_movers.items(), key=lambda x: -x[1]):
             mins = pts * 15
             leap_lines.append(f"  • {member}: {mins} min total")
+            for e in member_week_entries[member]:
+                desc = e.get("description", "").strip()
+                if desc:
+                    leap_lines.append(f"    – {desc}")
         sections.append("Big moves this week:\n" + "\n".join(leap_lines))
 
     # --- Expense fun facts ---

--- a/maBot.py
+++ b/maBot.py
@@ -1867,11 +1867,11 @@ def _build_weekly_report(data):
     )
 
     if not leaderboard:
-        return "Weekly Chore Report: No data yet."
+        return "Mario's Monday Mauling: No data yet."
 
     leader, leader_points = leaderboard[0]
     current_date = datetime.now().strftime("%Y-%m-%d")
-    sections = [f"Weekly Chore Report ({current_date})", f"Leader: {leader} with {leader_points} points"]
+    sections = [f"Mario's Monday Mauling, {current_date}", f"Leader: {leader} with {leader_points} points"]
 
     # --- Standings & penalties ---
     penalty_lines = []
@@ -1926,16 +1926,28 @@ def _build_weekly_report(data):
         for member, pts in sorted(big_movers.items(), key=lambda x: -x[1]):
             mins = pts * 15
             leap_lines.append(f"  • {member}: {mins} min total")
-            for e in member_week_entries[member]:
-                desc = e.get("description", "").strip()
-                if desc:
-                    leap_lines.append(f"    – {desc}")
+            descs = [
+                e.get("description", "").strip()
+                for e in member_week_entries[member]
+                if e.get("description", "").strip()
+            ]
+            if descs:
+                leap_lines.append(f"  ({', '.join(descs)})")
         sections.append("Big moves this week:\n" + "\n".join(leap_lines))
 
     # --- Expense fun facts ---
     fun_facts = _build_expense_fun_facts(data.get("expenses") or [])
     if fun_facts:
         sections.append(fun_facts)
+
+    # --- WG-Höck countdown ---
+    tz = pytz.timezone("Europe/Berlin")
+    now = datetime.now(tz)
+    days_until_wednesday = (2 - now.weekday()) % 7 or 7
+    next_wednesday = now + timedelta(days=days_until_wednesday)
+    sections.append(
+        f"📅 WG-Höck this week: Wednesday, {next_wednesday.strftime('%d.%m.')} ({days_until_wednesday} days away)"
+    )
 
     return "\n\n".join(sections)
 


### PR DESCRIPTION
Reformats the weekly report to match the new v2 spec.\n\n- **Title**: `Weekly Chore Report (DATE)` → `Mario's Monday Mauling, DATE`\n- **Big moves descriptions**: separate `– desc` sub-bullets → all descriptions joined as `(desc1, desc2)` on one indented line per member\n- **Section order**: Expense snapshot now appears before WG-Höck\n- **WG-Höck countdown** (new): always-last section, calculates days until next Wednesday — `📅 WG-Höck this week: Wednesday, DD.MM. (X days away)`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3)_