### PR TITLE
Reformat weekly report: new title, joined descriptions, expense before Höck

### DIFF
--- a/maBot.py
+++ b/maBot.py
@@ -1939,6 +1939,11 @@ def _build_weekly_report(data):
                 leap_lines.append(f"  ({', '.join(descs)})")
         sections.append("Big moves this week:\n" + "\n".join(leap_lines))
 
+    # --- Expense fun facts ---
+    fun_facts = _build_expense_fun_facts(data.get("expenses") or [])
+    if fun_facts:
+        sections.append(fun_facts)
+
     # --- WG-Höck reminder ---
     hoeck_date_str = data.get("wg_hoeck_date")
     if hoeck_date_str:
@@ -1954,20 +1959,6 @@ def _build_weekly_report(data):
                     sections.append(f"📅 WG-Höck this week: {day_name} ({days_until} day{'s' if days_until != 1 else ''} away)")
         except ValueError:
             pass
-
-    # --- Expense fun facts ---
-    fun_facts = _build_expense_fun_facts(data.get("expenses") or [])
-    if fun_facts:
-        sections.append(fun_facts)
-
-    # --- WG-Höck countdown ---
-    tz = pytz.timezone("Europe/Berlin")
-    now = datetime.now(tz)
-    days_until_wednesday = (2 - now.weekday()) % 7 or 7
-    next_wednesday = now + timedelta(days=days_until_wednesday)
-    sections.append(
-        f"📅 WG-Höck this week: Wednesday, {next_wednesday.strftime('%d.%m.')} ({days_until_wednesday} days away)"
-    )
 
     return "\n\n".join(sections)
 

--- a/maBot.py
+++ b/maBot.py
@@ -1871,11 +1871,11 @@ def _build_weekly_report(data):
     )
 
     if not leaderboard:
-        return "Weekly Chore Report: No data yet."
+        return "Mario's Monday Mauling: No data yet."
 
     leader, leader_points = leaderboard[0]
     current_date = datetime.now().strftime("%Y-%m-%d")
-    sections = [f"Weekly Chore Report ({current_date})", f"Leader: {leader} with {leader_points} points"]
+    sections = [f"Mario's Monday Mauling, {current_date}", f"Leader: {leader} with {leader_points} points"]
 
     # --- Standings & penalties ---
     penalty_lines = []
@@ -1930,10 +1930,13 @@ def _build_weekly_report(data):
         for member, pts in sorted(big_movers.items(), key=lambda x: -x[1]):
             mins = pts * 15
             leap_lines.append(f"  • {member}: {mins} min total")
-            for e in member_week_entries[member]:
-                desc = e.get("description", "").strip()
-                if desc:
-                    leap_lines.append(f"    – {desc}")
+            descs = [
+                e.get("description", "").strip()
+                for e in member_week_entries[member]
+                if e.get("description", "").strip()
+            ]
+            if descs:
+                leap_lines.append(f"  ({', '.join(descs)})")
         sections.append("Big moves this week:\n" + "\n".join(leap_lines))
 
     # --- WG-Höck reminder ---
@@ -1956,6 +1959,15 @@ def _build_weekly_report(data):
     fun_facts = _build_expense_fun_facts(data.get("expenses") or [])
     if fun_facts:
         sections.append(fun_facts)
+
+    # --- WG-Höck countdown ---
+    tz = pytz.timezone("Europe/Berlin")
+    now = datetime.now(tz)
+    days_until_wednesday = (2 - now.weekday()) % 7 or 7
+    next_wednesday = now + timedelta(days=days_until_wednesday)
+    sections.append(
+        f"📅 WG-Höck this week: Wednesday, {next_wednesday.strftime('%d.%m.')} ({days_until_wednesday} days away)"
+    )
 
     return "\n\n".join(sections)
 


### PR DESCRIPTION
Formatting adjustments to match the v2 spec:

- **Title**: `Weekly Chore Report (DATE)` → `Mario's Monday Mauling, DATE`
- **Big moves descriptions**: separate `– desc` sub-bullets → all descriptions joined as `(desc1, desc2)` on one indented line per member
- **Section order**: Expense snapshot now appears before the WG-Höck reminder (which stays data-driven from the admin-set date)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3)_