### PR TITLE
fix: handle stale receipt callbacks after bot restart

### DIFF
--- a/maBot.py
+++ b/maBot.py
@@ -2831,6 +2831,23 @@ def main():
 
     app.add_handler(chore_conv)
 
+    # Catch stale receipt inline-keyboard callbacks (e.g. after a bot restart)
+    async def _stale_receipt_cb(update: Update, context: CallbackContext) -> None:
+        query = update.callback_query
+        await query.answer()
+        await query.message.reply_text(
+            "This receipt session has expired (the bot may have restarted).\n"
+            "Please start a new expense via Add Expense → Scan Receipt.",
+            reply_markup=ReplyKeyboardRemove(),
+        )
+
+    app.add_handler(
+        CallbackQueryHandler(
+            _stale_receipt_cb,
+            pattern=r"^(?:receipt_toggle:.*|receipt_done|receipt_cancel)$",
+        )
+    )
+
     setup_weekly_job(app)
     setup_chronicler_backup_job(app)
 


### PR DESCRIPTION
After a bot restart, open receipt inline keyboards become unresponsive because ConversationHandler state is gone. Adds a low-priority global fallback that catches those stale callbacks and shows "session expired, start a new expense."

https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3)_