### PR TITLE
fix: correct multi-unit item amounts using our own arithmetic

### DIFF
--- a/maBot.py
+++ b/maBot.py
@@ -2831,6 +2831,23 @@ def main():
 
     app.add_handler(chore_conv)
 
+    # Catch stale receipt inline-keyboard callbacks (e.g. after a bot restart)
+    async def _stale_receipt_cb(update: Update, context: CallbackContext) -> None:
+        query = update.callback_query
+        await query.answer()
+        await query.message.reply_text(
+            "This receipt session has expired (the bot may have restarted).\n"
+            "Please start a new expense via Add Expense → Scan Receipt.",
+            reply_markup=ReplyKeyboardRemove(),
+        )
+
+    app.add_handler(
+        CallbackQueryHandler(
+            _stale_receipt_cb,
+            pattern=r"^(?:receipt_toggle:.*|receipt_done|receipt_cancel)$",
+        )
+    )
+
     setup_weekly_job(app)
     setup_chronicler_backup_job(app)
 

--- a/maBot.py
+++ b/maBot.py
@@ -20,7 +20,7 @@ from telegram import (
 )
 from telegram.ext import (
     Application, CommandHandler, MessageHandler, filters, CallbackContext,
-    ConversationHandler, CallbackQueryHandler,
+    ConversationHandler, CallbackQueryHandler, PicklePersistence,
 )
 from telegram.error import TelegramError
 
@@ -994,6 +994,13 @@ async def expense_receipt_confirm_total(update: Update, context: CallbackContext
         return EXPENSE_RECEIPT_CONFIRM_TOTAL
 
     items = context.user_data.get("receipt_items", [])
+    if not items:
+        await update.message.reply_text(
+            "Session data was lost (the bot may have restarted). Please send the receipt photo again.",
+            reply_markup=ReplyKeyboardMarkup([[KeyboardButton("Cancel")]], resize_keyboard=True),
+        )
+        return EXPENSE_RECEIPT
+
     context.user_data["confirmed_total"] = confirmed_total
     context.user_data["amount"] = confirmed_total
     context.user_data["receipt_selected"] = set(range(len(items)))
@@ -2607,7 +2614,8 @@ async def on_timeout(update: Update, context: CallbackContext) -> int:
 
 def main():
     data = load_data()
-    app = Application.builder().token(TOKEN).build()
+    persistence = PicklePersistence(filepath="bot_persistence.pkl")
+    app = Application.builder().token(TOKEN).persistence(persistence).build()
 
     app.add_handler(CommandHandler("start", start))
     app.add_handler(CommandHandler("expenses", list_expenses))

--- a/maBot.py
+++ b/maBot.py
@@ -698,10 +698,11 @@ def extract_items_from_receipt(image_path: str, mime_type: str = "image/jpeg"):
                         "type": "text",
                         "text": (
                             "Extract every purchased line item from this receipt and suggest a short expense description.\n"
-                            "Return ONLY a JSON object — no markdown, no explanation — in this format:\n"
-                            '{"description": "Migros groceries", "items": [{"name": "Product name", "amount": 9.95}, ...]}\n\n'
+                            "Return ONLY a JSON object — no markdown, no explanation — in this exact format:\n"
+                            '{"description": "Migros groceries", "receipt_total": 129.50, "items": [{"name": "Product name", "amount": 9.95}, ...]}\n\n'
                             "Rules:\n"
                             "- description: 2-4 words, store name + category (e.g. 'Migros groceries', 'Lidl snacks')\n"
+                            "- receipt_total: read the grand total printed at the bottom of the receipt (e.g. 'TOTAL CHF 129.50') — copy it exactly as a number\n"
                             "- For each item use the TOTAL column (the rightmost price on the line) as the amount — never multiply Menge × Preis yourself\n"
                             "- For weighted items (e.g. 0.275 kg) the Total column already shows the CHF amount charged; use it as-is\n"
                             "- For discounted items use the discounted/action price shown in the Total column, not the original price\n"
@@ -724,6 +725,12 @@ def extract_items_from_receipt(image_path: str, mime_type: str = "image/jpeg"):
         parsed = json.loads(raw[start:end])
         items = parsed["items"]
         description = str(parsed.get("description", "")).strip()
+        receipt_total = parsed.get("receipt_total")
+        if receipt_total is not None:
+            try:
+                receipt_total = round(float(receipt_total), 2)
+            except (TypeError, ValueError):
+                receipt_total = None
     except (ValueError, json.JSONDecodeError, KeyError) as exc:
         raise ReceiptParsingError(f"Could not parse API response as JSON: {exc}") from exc
 
@@ -744,6 +751,7 @@ def extract_items_from_receipt(image_path: str, mime_type: str = "image/jpeg"):
 
     return {
         "description": description,
+        "receipt_total": receipt_total,
         "items": normalised,
     }
 
@@ -949,23 +957,25 @@ async def expense_receipt_photo(update: Update, context: CallbackContext) -> int
         )
         return EXPENSE_RECEIPT_MANUAL
 
-    parsed_total = round(sum(item["amount"] for item in items), 2)
+    items_sum = round(sum(item["amount"] for item in items), 2)
+    receipt_total = result.get("receipt_total") if isinstance(result, dict) else None
+    suggested_total = receipt_total if receipt_total else items_sum
 
     context.user_data["mode"] = "receipt"
     context.user_data["receipt_items"] = items
-    context.user_data["receipt_parsed_total"] = parsed_total
+    context.user_data["receipt_parsed_total"] = items_sum
     if isinstance(result, dict) and result.get("description"):
         context.user_data["receipt_description"] = result["description"]
 
     await analysing_msg.delete()
     total_kb = ReplyKeyboardMarkup(
-        [[f"{parsed_total:.2f}"]],
+        [[f"{suggested_total:.2f}"]],
         one_time_keyboard=True,
         resize_keyboard=True,
     )
     await update.message.reply_text(
-        f"Found {len(items)} items. Parsed total: <b>CHF {parsed_total:.2f}</b>\n"
-        "Does this match your receipt? Tap to confirm or type the correct total:",
+        f"Found {len(items)} items. Receipt total: <b>CHF {suggested_total:.2f}</b>\n"
+        "Tap to confirm or type the correct total:",
         parse_mode="HTML",
         reply_markup=total_kb,
     )

--- a/maBot.py
+++ b/maBot.py
@@ -699,17 +699,17 @@ def extract_items_from_receipt(image_path: str, mime_type: str = "image/jpeg"):
                         "text": (
                             "Extract every purchased line item from this receipt and suggest a short expense description.\n"
                             "Return ONLY a JSON object — no markdown, no explanation — in this exact format:\n"
-                            '{"description": "Migros groceries", "receipt_total": 129.50, "items": [{"name": "Product name", "amount": 9.95}, ...]}\n\n'
+                            '{"description": "Migros groceries", "receipt_total": 129.50, "items": [{"name": "Product name", "qty": 1, "unit_price": 9.95, "amount": 9.95}, ...]}\n\n'
                             "Rules:\n"
                             "- description: 2-4 words, store name + category (e.g. 'Migros groceries', 'Lidl snacks')\n"
-                            "- receipt_total: read the grand total printed at the bottom of the receipt (e.g. 'TOTAL CHF 129.50') — copy it exactly as a number\n"
-                            "- For each item use the TOTAL column (the rightmost price on the line) as the amount — never multiply Menge × Preis yourself\n"
-                            "- For weighted items (e.g. 0.275 kg) the Total column already shows the CHF amount charged; use it as-is\n"
-                            "- For discounted items use the discounted/action price shown in the Total column, not the original price\n"
-                            "- For multi-quantity items (e.g. Menge=2) the Total column already reflects the full line total; use it\n"
-                            "- If the same product name appears on multiple lines (e.g. Bauernspeck twice with different weights), list EACH line as a separate item — do not merge them\n"
+                            "- receipt_total: the grand total printed at the bottom (e.g. 'TOTAL CHF 129.50') — copy exactly as a number\n"
+                            "- qty: the Menge column value (can be fractional for weighted items, e.g. 0.275)\n"
+                            "- unit_price: the Preis column value (unit price or per-kg price)\n"
+                            "- amount: qty × unit_price — always compute this yourself for every item\n"
+                            "- For discounted items: unit_price and amount should reflect the discounted price (Aktion column), not the original\n"
+                            "- If the same product name appears on multiple lines (different weights), list EACH as a separate item; append weight to disambiguate\n"
                             "- Exclude header rows, subtotals, receipt totals, tax lines, and loyalty/points lines\n"
-                            "- Keep item names short but recognisable; append weight (e.g. '0.128kg') to disambiguate duplicate names"
+                            "- Keep item names short but recognisable"
                         ),
                     },
                 ],
@@ -742,7 +742,19 @@ def extract_items_from_receipt(image_path: str, mime_type: str = "image/jpeg"):
         for i in items:
             if not isinstance(i, dict) or "name" not in i or i.get("amount") is None:
                 continue
-            normalised.append({"name": str(i["name"]), "amount": round(float(i["amount"]), 2)})
+            amount = round(float(i["amount"]), 2)
+            # If GPT returned unit_price and qty, recompute for integer-qty > 1 items
+            # (GPT often returns the Preis/unit column instead of the Total column for these)
+            try:
+                qty = float(i.get("qty") or 1)
+                unit_price = float(i.get("unit_price") or 0)
+                if unit_price > 0 and qty == int(qty) and int(qty) > 1:
+                    computed = round(qty * unit_price, 2)
+                    if abs(computed - amount) > 0.005:
+                        amount = computed
+            except (TypeError, ValueError):
+                pass
+            normalised.append({"name": str(i["name"]), "amount": amount})
     except (TypeError, ValueError, KeyError) as exc:
         raise ReceiptParsingError(f"Failed to parse item data: {exc}") from exc
 


### PR DESCRIPTION
GPT consistently reads the Preis (unit price) column instead of the Total column for items with integer qty > 1 (e.g. qty=2, unit=2.00 → GPT returns 2.00 instead of 4.00).

Fix: ask GPT to return `qty` and `unit_price` per item. Our code then recomputes `amount = qty × unit_price` whenever they disagree with the GPT-returned amount. Weighted items (fractional qty) are not affected by the correction path.

Prompt also updated to instruct GPT to compute `amount = qty × unit_price` itself, as a belt-and-suspenders approach.

https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3)_