### PR TITLE
chore: provision tesseract during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,5 +22,11 @@ jobs:
             git fetch origin main
             git checkout main
             git pull --ff-only origin main
+            sudo DEBIAN_FRONTEND=noninteractive dpkg --configure -a
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+              tesseract-ocr \
+              tesseract-ocr-deu \
+              tesseract-ocr-eng
             ./venv/bin/python -m pip install -q -r requirements.txt
             systemctl restart wg_cop


### PR DESCRIPTION
## Summary
- repair interrupted `dpkg` state before package installation
- install `tesseract-ocr` plus German and English language packs during deploy
- keep OCR provisioning automatic and idempotent on every `main` deploy

## Why
Receipt scanning now prefers local Tesseract OCR, but the server did not have the system package installed. This change moves that repeated setup into the deployment workflow instead of relying on manual apt commands.