### PR TITLE
feat: penalty beer redemption, /cancel fix, admin report time, deploy docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 # Ignore bot token and user data
+wg_data_alpha.json
+wg_data_alpha.json.tmp
+wg_data_alpha.json.*.bak
 wg_data_beta.json
 porter*
 *.pyc

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# =============================================================================
+# wg-cop — server reference for agents and humans
+# =============================================================================
+#
+# DEPLOY METHOD: 100% GitHub Actions — do NOT manually push code to the server.
+#   Trigger: push to `main` branch → .github/workflows/deploy.yml fires.
+#   The workflow SSHes into the server and runs: git reset --hard origin/main,
+#   pip install, systemctl restart wg_cop.
+#
+# To deploy: merge your branch to main (via PR or direct push).
+#
+# =============================================================================
+# SERVER ACCESS
+# =============================================================================
+#   Host : 82.165.45.100
+#   User : root
+#   SSH  : ssh root@82.165.45.100
+#   (Key must be configured in your local ~/.ssh or provided as SSH_KEY secret)
+#
+# =============================================================================
+# SERVER LAYOUT
+# =============================================================================
+#   /usr/bots/wg_cop/          — git repo (tracks origin/main)
+#   /usr/bots/wg_cop/venv/     — Python virtualenv
+#   /usr/bots/wg_cop/config.py — secrets (NOT in git, stays on server)
+#   /usr/bots/wg_cop/wg_data_alpha.json  — live database (NOT in git)
+#
+# =============================================================================
+# USEFUL COMMANDS (run on the server via ssh)
+# =============================================================================
+
+set -euo pipefail
+
+SERVER="root@82.165.45.100"
+BOT_DIR="/usr/bots/wg_cop"
+SERVICE="wg_cop"
+
+cmd() { ssh "$SERVER" "$@"; }
+
+case "${1:-help}" in
+
+  status)
+    # Show systemd service status and last 40 log lines
+    cmd "systemctl status $SERVICE --no-pager && journalctl -u $SERVICE -n 40 --no-pager"
+    ;;
+
+  logs)
+    # Stream live logs  (Ctrl-C to stop)
+    ssh "$SERVER" "journalctl -u $SERVICE -f"
+    ;;
+
+  restart)
+    # Emergency restart without a full deploy (no code change)
+    echo "Restarting $SERVICE on $SERVER …"
+    cmd "systemctl restart $SERVICE"
+    cmd "systemctl status $SERVICE --no-pager"
+    ;;
+
+  data)
+    # Download the live database to /tmp/wg_data_live.json
+    scp "$SERVER:$BOT_DIR/wg_data_alpha.json" /tmp/wg_data_live.json
+    echo "Saved to /tmp/wg_data_live.json"
+    ;;
+
+  push-data)
+    # Upload a local JSON file to the server (emergency data restore)
+    # Usage: ./deploy.sh push-data /path/to/file.json
+    LOCAL="${2:?usage: deploy.sh push-data <local-file.json>}"
+    echo "Uploading $LOCAL → $SERVER:$BOT_DIR/wg_data_alpha.json"
+    echo "Press Ctrl-C within 5s to abort …"; sleep 5
+    scp "$LOCAL" "$SERVER:$BOT_DIR/wg_data_alpha.json"
+    cmd "systemctl restart $SERVICE"
+    echo "Done. Service restarted."
+    ;;
+
+  help|*)
+    grep "^#" "$0" | sed 's/^# \{0,1\}//'
+    echo ""
+    echo "Usage: $0 {status|logs|restart|data|push-data <file>}"
+    ;;
+
+esac

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,33 +1,38 @@
 #!/usr/bin/env bash
 # =============================================================================
-# wg-cop — server reference for agents and humans
+# mario_robotta / wg-cop — server reference for agents and humans
 # =============================================================================
 #
-# DEPLOY METHOD: 100% GitHub Actions — do NOT manually push code to the server.
-#   Trigger: push to `main` branch → .github/workflows/deploy.yml fires.
-#   The workflow SSHes into the server and runs: git reset --hard origin/main,
-#   pip install, systemctl restart wg_cop.
+# PRIMARY DEPLOY METHOD: GitHub Actions (100% automated)
+#   Trigger : push to `main` branch
+#   Workflow : .github/workflows/deploy.yml
+#   What it does:
+#     ssh into server → git reset --hard origin/main → pip install → systemctl restart
+#   To deploy: merge your branch to main (PR or direct push to main).
+#   Do NOT scp code, do NOT git push to the server manually.
 #
-# To deploy: merge your branch to main (via PR or direct push).
-#
-# =============================================================================
-# SERVER ACCESS
-# =============================================================================
-#   Host : 82.165.45.100
-#   User : root
-#   SSH  : ssh root@82.165.45.100
-#   (Key must be configured in your local ~/.ssh or provided as SSH_KEY secret)
-#
-# =============================================================================
-# SERVER LAYOUT
-# =============================================================================
-#   /usr/bots/wg_cop/          — git repo (tracks origin/main)
-#   /usr/bots/wg_cop/venv/     — Python virtualenv
-#   /usr/bots/wg_cop/config.py — secrets (NOT in git, stays on server)
-#   /usr/bots/wg_cop/wg_data_alpha.json  — live database (NOT in git)
+# EMERGENCY FALLBACK (GitHub Actions broken):
+#   Use the parent deploy.sh, two directories above this file:
+#     ../../deploy.sh mario_robotta
+#   That script rsyncs from your local main to the server.
+#   Git remote alias for this repo on your Mac: jaenib-wgcop
 #
 # =============================================================================
-# USEFUL COMMANDS (run on the server via ssh)
+# SERVER
+# =============================================================================
+#   Host        : 82.165.45.100
+#   User        : root
+#   SSH         : ssh root@82.165.45.100
+#   Bot dir     : /usr/bots/wg_cop/
+#   Service     : wg_cop   (systemctl)
+#   Venv        : /usr/bots/wg_cop/venv/
+#
+# Files NOT in git (stay on server):
+#   config.py            — bot token + Telegram IDs (secrets)
+#   wg_data_alpha.json   — live expense/chore/penalty database
+#
+# =============================================================================
+# UTILITY COMMANDS
 # =============================================================================
 
 set -euo pipefail
@@ -36,42 +41,36 @@ SERVER="root@82.165.45.100"
 BOT_DIR="/usr/bots/wg_cop"
 SERVICE="wg_cop"
 
-cmd() { ssh "$SERVER" "$@"; }
-
 case "${1:-help}" in
 
   status)
-    # Show systemd service status and last 40 log lines
-    cmd "systemctl status $SERVICE --no-pager && journalctl -u $SERVICE -n 40 --no-pager"
+    ssh "$SERVER" "systemctl status $SERVICE --no-pager && journalctl -u $SERVICE -n 40 --no-pager"
     ;;
 
   logs)
-    # Stream live logs  (Ctrl-C to stop)
     ssh "$SERVER" "journalctl -u $SERVICE -f"
     ;;
 
   restart)
-    # Emergency restart without a full deploy (no code change)
-    echo "Restarting $SERVICE on $SERVER …"
-    cmd "systemctl restart $SERVICE"
-    cmd "systemctl status $SERVICE --no-pager"
+    echo "Restarting $SERVICE …"
+    ssh "$SERVER" "systemctl restart $SERVICE && systemctl status $SERVICE --no-pager"
     ;;
 
   data)
-    # Download the live database to /tmp/wg_data_live.json
+    # Download live database
     scp "$SERVER:$BOT_DIR/wg_data_alpha.json" /tmp/wg_data_live.json
     echo "Saved to /tmp/wg_data_live.json"
     ;;
 
   push-data)
-    # Upload a local JSON file to the server (emergency data restore)
-    # Usage: ./deploy.sh push-data /path/to/file.json
-    LOCAL="${2:?usage: deploy.sh push-data <local-file.json>}"
-    echo "Uploading $LOCAL → $SERVER:$BOT_DIR/wg_data_alpha.json"
-    echo "Press Ctrl-C within 5s to abort …"; sleep 5
+    # Emergency: upload a repaired database and restart
+    # Usage: ./deploy.sh push-data /path/to/wg_data_alpha.json
+    LOCAL="${2:?usage: deploy.sh push-data <file.json>}"
+    echo "Uploading $LOCAL → $SERVER:$BOT_DIR/wg_data_alpha.json (restarting in 5s…)"
+    sleep 5
     scp "$LOCAL" "$SERVER:$BOT_DIR/wg_data_alpha.json"
-    cmd "systemctl restart $SERVICE"
-    echo "Done. Service restarted."
+    ssh "$SERVER" "systemctl restart $SERVICE"
+    echo "Done."
     ;;
 
   help|*)

--- a/maBot.py
+++ b/maBot.py
@@ -3382,9 +3382,11 @@ def main():
         entry_points=[MessageHandler(filters.Regex("^Adjust Beer Count$"), admin_beer_start)],
         states={
             ADMIN_BEER_MEMBER: [
+                MessageHandler(filters.Regex("^Cancel$"), cancel),
                 MessageHandler(filters.TEXT & ~filters.COMMAND, admin_beer_member)
             ],
             ADMIN_BEER_COUNT: [
+                MessageHandler(filters.Regex("^Cancel$"), cancel),
                 MessageHandler(filters.TEXT & ~filters.COMMAND, admin_beer_count)
             ],
             ConversationHandler.TIMEOUT: [
@@ -3403,7 +3405,10 @@ def main():
     admin_hoeck_conv = ConversationHandler(
         entry_points=[MessageHandler(filters.Regex(r"^Set WG-Höck$"), admin_hoeck_start)],
         states={
-            0: [MessageHandler(filters.TEXT & ~filters.COMMAND, admin_hoeck_date)],
+            0: [
+                MessageHandler(filters.Regex("^Cancel$"), cancel),
+                MessageHandler(filters.TEXT & ~filters.COMMAND, admin_hoeck_date),
+            ],
             ConversationHandler.TIMEOUT: [
                 MessageHandler(filters.ALL, on_timeout)
             ],
@@ -3420,7 +3425,10 @@ def main():
     admin_report_time_conv = ConversationHandler(
         entry_points=[MessageHandler(filters.Regex("^Set Report Time$"), admin_report_time_start)],
         states={
-            ADMIN_REPORT_TIME: [MessageHandler(filters.TEXT & ~filters.COMMAND, admin_report_time_set)],
+            ADMIN_REPORT_TIME: [
+                MessageHandler(filters.Regex("^Cancel$"), cancel),
+                MessageHandler(filters.TEXT & ~filters.COMMAND, admin_report_time_set),
+            ],
             ConversationHandler.TIMEOUT: [
                 MessageHandler(filters.ALL, on_timeout)
             ],
@@ -3455,6 +3463,7 @@ def main():
                 MessageHandler(filters.TEXT & ~filters.COMMAND, expense_receipt_confirm_total),
             ],
             EXPENSE_RECEIPT_MANUAL: [
+                MessageHandler(filters.Regex("^Cancel$"), cancel),
                 MessageHandler(
                     filters.TEXT & ~filters.COMMAND, expense_receipt_manual_items
                 )
@@ -3561,10 +3570,12 @@ def main():
         states={
             REDEEM_MEMBER: [
                 MessageHandler(_nav_pattern, cancel),
+                MessageHandler(filters.Regex("^Cancel$"), cancel),
                 MessageHandler(filters.TEXT & ~filters.COMMAND, redeem_member),
             ],
             REDEEM_COUNT: [
                 MessageHandler(_nav_pattern, cancel),
+                MessageHandler(filters.Regex("^Cancel$"), cancel),
                 MessageHandler(filters.TEXT & ~filters.COMMAND, redeem_count),
             ],
             ConversationHandler.TIMEOUT: [

--- a/maBot.py
+++ b/maBot.py
@@ -3358,7 +3358,6 @@ def main():
 
     app.add_handler(CommandHandler("start", start))
     app.add_handler(CommandHandler("expenses", list_expenses))
-    app.add_handler(CommandHandler("cancel", cancel))
     app.add_handler(CommandHandler("chore", handle_chore))
     app.add_handler(CommandHandler("chores", list_chores))
     app.add_handler(CommandHandler("setstatus", set_vacation_status))
@@ -3376,7 +3375,6 @@ def main():
     app.add_handler(MessageHandler(filters.Regex("^Back to Settings$"), back_to_settings))
     app.add_handler(MessageHandler(filters.Regex("^Trigger Weekly Report$"), admin_trigger_report))
     app.add_handler(MessageHandler(filters.Regex("^Manage "), open_manage_self))
-    app.add_handler(MessageHandler(filters.Regex("^Cancel$"), cancel))
 
     admin_beer_conv = ConversationHandler(
         entry_points=[MessageHandler(filters.Regex("^Adjust Beer Count$"), admin_beer_start)],
@@ -3632,6 +3630,13 @@ def main():
             pattern=r"^(?:receipt_toggle:.*|receipt_done|receipt_cancel)$",
         )
     )
+
+    # Top-level cancel — registered LAST so each ConversationHandler's own
+    # fallback gets first shot at /cancel and can properly end the conversation.
+    # If we registered these earlier, they would swallow /cancel before the
+    # ConversationHandler ever sees it, leaving the user stuck in their state.
+    app.add_handler(CommandHandler("cancel", cancel))
+    app.add_handler(MessageHandler(filters.Regex("^Cancel$"), cancel))
 
     _startup_data = load_data()
     _rh, _rm = _parse_report_time(_startup_data.get("weekly_report_time", "09:30"))


### PR DESCRIPTION
## Summary

- **feat: Set Report Time** — admin panel now lets the bot handler change the weekly report schedule (stored in `wg_data_alpha.json`, survives restarts)
- **fix: `/cancel` actually ends conversations** — top-level `CommandHandler("cancel")` was registered before all `ConversationHandler`s, so it swallowed `/cancel` without telling the conv to end. Users were left stuck in their state even after seeing "Cancelled." Moved both top-level cancel handlers to after all conversation handlers so each conv's own fallback fires first.
- **fix: Cancel button works in all states** — seven states (`EXPENSE_RECEIPT_MANUAL`, `REDEEM_MEMBER`, `REDEEM_COUNT`, `ADMIN_BEER_MEMBER`, `ADMIN_BEER_COUNT`, `ADMIN_REPORT_TIME`, `ADMIN_HOECK_DATE`) had bare `filters.TEXT & ~filters.COMMAND` handlers that intercepted the "Cancel" keyboard button before the fallback could fire. Added explicit cancel handlers at the top of each.
- **fix: protect `wg_data_alpha.json` from `git clean`** — deploy workflow's `git clean -fd` was wiping the live database. Added to `.gitignore`.
- **docs: `deploy.sh`** — canonical agent/human reference for server access, deploy chain, and emergency utility commands. Aligned with parent `../../deploy.sh` (multi-bot rsync script that already documents GHA as the primary method for mario_robotta).

## Test plan

- [ ] Redeem Beer → select member → type `/cancel` → conversation ends, main menu shown, re-entering Redeem Beer starts fresh
- [ ] Scan receipt → OCR fails → enter manual text → tap Cancel button → returns to main menu (not "I couldn't understand any items")
- [ ] Admin panel → Set Report Time → type `/cancel` → returns cleanly
- [ ] Push to `main` → GitHub Actions deploys → `wg_data_alpha.json` survives on server
- [ ] `./deploy.sh status` connects and shows service status

https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3)_