### PR TITLE
Preserve venv across deploys; add openai to requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ __pycache__/
 .env
 config.py
 .venv/
+venv/
 .secrets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-telegram-bot>=20.0
 python-telegram-bot[job-queue]
 pytz
-Pillow
+openai


### PR DESCRIPTION
## Summary

The deploy log was truncating mid-wipe at `Removing venv/lib/python3.10/site-packages/PIL/...` — two root causes:

1. **`.gitignore` had `.venv/`** (local dev convention) but the server's venv lives at `venv/` (no dot). `git clean -fd` in the deploy workflow respects `.gitignore` — un-ignored `venv/` got nuked on every push to main, forcing a full pip reinstall and risking SSH timeout mid-deploy. → Add `venv/` to `.gitignore`.

2. **`openai` was missing from `requirements.txt`** — the bot worked because a prior manual install left it in the venv. Now that venv gets rebuilt cleanly, openai would not return. → Add it.

Also dropped `Pillow` — no longer imported after the tesseract removal.

## Test plan

- [ ] Watch deploy log after merge — should be much faster (no venv rebuild)
- [ ] `ssh root@82.165.45.100 "ls /usr/bots/wg_cop/venv/bin/python && /usr/bots/wg_cop/venv/bin/python -c 'import openai; print(openai.__version__)'"`
- [ ] Bot service should restart and pick up the new code from PR #42 and #43

https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKKdXQAM2z2QG3itsjqMT3)_